### PR TITLE
add support for both antsdr-e310 and antsdr-e200

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ export CROSS_COMPILE=arm-linux-gnueabihf-
 export PATH=$PATH:/opt/Xilinx/SDK/2019.1/gnu/aarch32/lin/gcc-arm-linux-gnueabi/bin 
 export VIVADO_SETTINGS=/opt/Xilinx/Vivado/2019.1/settings64.sh
 export PERL_MM_OPT=
+
+# you should export the right deivce to build the firmware, 
+# by default the TARGET is ant, you should export the right deivces
+# for example: 
+# export TARGET=antsdre200
+# export TARGET=ant
+export TARGET=ant
 ```
 
 ### Building ANTSDR E310 firmware

--- a/scripts/ant.its
+++ b/scripts/ant.its
@@ -17,27 +17,12 @@
 
 		fdt@1 {
 			description = "zynq-pluto-sdr";
-			data = /incbin/("../build/zynq-ant-sdr.dtb");
+			data = /incbin/("../build/zynq-ant.dtb");
 			type = "flat_dt";
 			arch = "arm";
 			compression = "none";
 		};
 
-		fdt@2 {
-			description = "zynq-pluto-sdr-revb";
-			data = /incbin/("../build/zynq-ant-sdr-revb.dtb");
-			type = "flat_dt";
-			arch = "arm";
-			compression = "none";
-		};
-
-		fdt@3 {
-			description = "zynq-pluto-sdr-revc";
-			data = /incbin/("../build/zynq-ant-sdr-revc.dtb");
-			type = "flat_dt";
-			arch = "arm";
-			compression = "none";
-		};
 
 		fpga@1 {
 			description = "FPGA";

--- a/scripts/ant.mk
+++ b/scripts/ant.mk
@@ -2,7 +2,7 @@
 # Target specific constants go here
 
 HDF_URL:=http://github.com/analogdevicesinc/plutosdr-fw/releases/download/${LATEST_TAG}/system_top.hdf
-TARGET_DTS_FILES:= zynq-ant-sdr.dtb zynq-ant-sdr-revb.dtb zynq-ant-sdr-revc.dtb
+TARGET_DTS_FILES:= zynq-ant.dtb 
 COMPLETE_NAME:=ANTSDR
 ZIP_ARCHIVE_PREFIX:=antsdr
 DEVICE_VID:=0x0456

--- a/scripts/antsdre200.its
+++ b/scripts/antsdre200.its
@@ -1,0 +1,174 @@
+/*
+ * U-Boot uImage source file with multiple kernels, ramdisks and FDT blobs
+ * This example makes use of the 'loadables' field
+ */
+
+/*
+ * fdt get addr foo /images/fdt@1 data
+ */
+
+/dts-v1/;
+
+/ {
+	description = "Configuration to load fpga before Kernel";
+	magic = "ITB PlutoSDR (ADALM-PLUTO)";
+	#address-cells = <1>;
+	images {
+
+		fdt@1 {
+			description = "zynq-pluto-sdr";
+			data = /incbin/("../build/zynq-antsdre200.dtb");
+			type = "flat_dt";
+			arch = "arm";
+			compression = "none";
+		};
+
+		fdt@2 {
+			description = "zynq-pluto-sdr";
+			data = /incbin/("../build/zynq-antsdre200.dtb");
+			type = "flat_dt";
+			arch = "arm";
+			compression = "none";
+		};
+
+		fdt@3 {
+			description = "zynq-pluto-sdr";
+			data = /incbin/("../build/zynq-antsdre200.dtb");
+			type = "flat_dt";
+			arch = "arm";
+			compression = "none";
+		};
+
+		fpga@1 {
+			description = "FPGA";
+			data = /incbin/("../build/system_top.bit");
+			type = "fpga";
+			arch = "arm";
+			compression = "none";
+			load = <0xF000000>;
+			hash@1 {
+				algo = "md5";
+			};
+		};
+
+		linux_kernel@1 {
+			description = "Linux";
+			data = /incbin/("../build/zImage");
+			type = "kernel";
+			arch = "arm";
+			os = "linux";
+			compression = "none";
+			load = <0x8000>;
+			entry = <0x8000>;
+			hash@1 {
+				algo = "md5";
+			};
+		};
+		ramdisk@1 {
+			description = "Ramdisk";
+			data = /incbin/("../build/rootfs.cpio.gz");
+			type = "ramdisk";
+			arch = "arm";
+			os = "linux";
+			compression = "gzip";
+			hash@1 {
+				algo = "md5";
+			};
+		};
+
+	};
+
+	configurations {
+		default = "config@0";
+		config@0 {
+			description = "Linux with fpga RevA";
+			fdt = "fdt@1";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		/* all below is currently RevB ! */
+
+		config@1 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@2 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@3 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@4 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@5 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@6 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+
+		config@7 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@8 { /* This one is actually RevC */
+			description = "Linux with fpga RevC";
+			fdt = "fdt@3";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@9 { /* This one is actually RevB */
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@10 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+	};
+};

--- a/scripts/antsdre200.mk
+++ b/scripts/antsdre200.mk
@@ -1,0 +1,10 @@
+
+# Target specific constants go here
+
+HDF_URL:=http://github.com/analogdevicesinc/plutosdr-fw/releases/download/${LATEST_TAG}/system_top.hdf
+TARGET_DTS_FILES:= zynq-antsdre200.dtb
+COMPLETE_NAME:=ANTSDR
+ZIP_ARCHIVE_PREFIX:=antsdr
+DEVICE_VID:=0x0456
+DEVICE_PID:=0xb673
+


### PR DESCRIPTION
In the top level makefile, user should decide which device they will need to make, just export the TARGET=ant or TARGET=antsdre200